### PR TITLE
Various improvements

### DIFF
--- a/src/ob-pwsh.el
+++ b/src/ob-pwsh.el
@@ -27,7 +27,7 @@
          (expanded-body (org-babel-expand-body:pwsh body params))
          (result-type (nth 0 parsed-params))
          (vars (nth 1 parsed-params))
-         (temp-file (make-temp-file "ob-pwsh-")))
+         (temp-file (make-temp-file "ob-pwsh-" nil ".ps1")))
     (message (format "===vars %s" vars))
     ;; Build script in temporary file
     (with-temp-file temp-file

--- a/src/ob-pwsh.el
+++ b/src/ob-pwsh.el
@@ -10,11 +10,14 @@
 
 (add-to-list 'org-src-lang-modes '("pwsh" . powershell))
 
-(defvar org-babel-default-header-args:pwsh '((:lang . "pwsh"))
-  "A list of default header args for Pwsh code blocks.")
+(defcustom org-babel-default-header-args:pwsh '((:lang . "pwsh"))
+  "A list of default header args for Pwsh code blocks."
+  :type '(alist :key-type (symbol :tag "Keyword") :value-type (string :tag "Value")))
 
-(defvar org-babel-command:pwsh "pwsh"
-  "The path to the Pwsh interpreter executable.")
+(defcustom org-babel-command:pwsh "pwsh"
+  "The path to the Pwsh interpreter executable."
+  :group 'ob-pwsh
+  :type 'string)
 
 ;; -- Babel Functions --
 

--- a/src/ob-pwsh.el
+++ b/src/ob-pwsh.el
@@ -8,6 +8,8 @@
 
 (add-to-list 'org-babel-tangle-lang-exts '("Pwsh" . "ps"))
 
+(add-to-list 'org-src-lang-modes '("pwsh" . powershell))
+
 (defvar org-babel-default-header-args:pwsh '((:lang . "pwsh"))
   "A list of default header args for Pwsh code blocks.")
 


### PR DESCRIPTION
This is a very useful library! I made a few improvements that I thought might be generally applicable:

* Add `.ps1` extension to temporary files
* Translate Emacs Lisp values into PowerShell forms when passing variables
* Use `powershell-mode` for source blocks
* Declare settings using `defcustom`

The translation of values relies on `powershell-mode`’s `powershell-doublequote-selection`, so I have a comment at the top wondering whether that should be a hard requirement (since it’s already being used for highlighting). Other than that, I think this PR is ready to go.